### PR TITLE
Add "Create Note from HackMD URL" feature

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,25 +1,12 @@
 import { requestUrl } from 'obsidian';
 import {
-  NotePermissionRole,
-  CommentPermissionType,
-} from '@hackmd/api/dist/type';
-import { HackMDError, HackMDErrorType } from './types';
-
-// Response type for HackMD API requests
-interface HackMDResponse {
-  status: number;
-  data: any;
-  ok: boolean;
-}
-
-// Options for creating or updating a HackMD note
-interface NoteOptions {
-  title?: string;
-  content?: string;
-  readPermission?: NotePermissionRole;
-  writePermission?: NotePermissionRole;
-  commentPermission?: CommentPermissionType;
-}
+  HackMDError,
+  HackMDErrorType,
+  HackMDNote,
+  HackMDResponse,
+  HackMDUser,
+  NoteOptions,
+} from './types';
 
 // Client for interacting with the HackMD API
 export class HackMDClient {
@@ -67,7 +54,7 @@ export class HackMDClient {
   private async request(
     method: string,
     endpoint: string,
-    data?: any
+    data?: NoteOptions
   ): Promise<HackMDResponse> {
     const url = `${this.baseUrl}${endpoint}`;
     try {
@@ -141,52 +128,78 @@ export class HackMDClient {
     }
   }
 
+  private isHackMDUser(data: unknown): data is HackMDUser {
+    return (
+      typeof data === 'object' &&
+      data !== null &&
+      'id' in data &&
+      'name' in data &&
+      'userPath' in data
+    );
+  }
+
   // Gets the current user's information
-  async getMe() {
+  async getMe(): Promise<HackMDUser> {
     const response = await this.request('GET', '/me');
-    return response.data;
+    if (!response.data || !this.isHackMDUser(response.data)) {
+      throw new HackMDError(
+        'Failed to get user information',
+        HackMDErrorType.NOT_FOUND
+      );
+    }
+    return response.data as HackMDUser;
   }
 
   // Gets a note by ID
-  async getNote(noteId: string) {
+  async getNote(noteId: string): Promise<HackMDNote> {
     const response = await this.request('GET', `/notes/${noteId}`);
-    return response.data;
+    if (!response.data) {
+      throw new HackMDError(
+        `Note ${noteId} not found`,
+        HackMDErrorType.NOT_FOUND
+      );
+    }
+    return response.data as HackMDNote;
   }
 
   // Creates a new note
-  async createNote(options: NoteOptions) {
-    const data = {
-      content: options.content || '',
-      readPermission: options.readPermission,
-      writePermission: options.writePermission,
-      commentPermission: options.commentPermission,
-    };
-
-    const response = await this.request('POST', '/notes', data);
-    return response.data;
+  async createNote(options: NoteOptions): Promise<HackMDNote> {
+    const response = await this.request('POST', '/notes', options);
+    if (!response.data) {
+      throw new HackMDError('Failed to create note', HackMDErrorType.UNKNOWN);
+    }
+    return response.data as HackMDNote;
   }
 
   // Updates an existing note
-  async updateNote(noteId: string, options: NoteOptions) {
+  async updateNote(noteId: string, options: NoteOptions): Promise<HackMDNote> {
     const response = await this.request('PATCH', `/notes/${noteId}`, options);
-    // Handle 202 Accepted response
+
     if (response.status === 202) {
       await new Promise(resolve => setTimeout(resolve, 1000));
       return this.getNote(noteId);
     }
-    return response.data;
+
+    if (!response.data) {
+      throw new HackMDError(
+        `Failed to update note ${noteId}`,
+        HackMDErrorType.UNKNOWN
+      );
+    }
+    return response.data as HackMDNote;
   }
 
   // Deletes a note
   async deleteNote(noteId: string): Promise<boolean> {
     const response = await this.request('DELETE', `/notes/${noteId}`);
-    // Both successful deletion and "already deleted" cases return true
     if (response.status === 404) {
       console.debug(`Note ${noteId} was already deleted or doesn't exist`);
     }
+    // Both successful deletion and "already deleted" cases return true
     return true;
   }
 
+  // Extracts note ID from HackMD URL
   public getIdFromUrl(url: string): string | null {
     const match = url.match(/hackmd\.io\/(?:@[^/]+\/)?([a-zA-Z0-9_-]+)/);
     return match ? match[1] : null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,19 +23,38 @@ interface NoteOptions {
 
 // Client for interacting with the HackMD API
 export class HackMDClient {
+  private static instance: HackMDClient;
+  private static accessToken: string;
   private readonly baseUrl = 'https://api.hackmd.io/v1';
   private readonly headers: Record<string, string>;
 
-  /**
-   * Creates a new HackMD client
-   * @param accessToken - HackMD API access token
-   */
-  constructor(accessToken: string) {
+  private constructor(accessToken: string) {
     this.headers = {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     };
+  }
+
+  public static async getInstance(accessToken: string): Promise<HackMDClient> {
+    if (!accessToken) {
+      throw new HackMDError(
+        'Failed to initialize HackMD client. Check your access token.',
+        HackMDErrorType.AUTH_FAILED
+      );
+    }
+
+    if (HackMDClient.instance && HackMDClient.accessToken === accessToken) {
+      return HackMDClient.instance;
+    }
+    HackMDClient.instance = new HackMDClient(accessToken);
+    HackMDClient.accessToken = accessToken;
+    await HackMDClient.instance.getMe(); // Verify token works
+    return HackMDClient.instance;
+  }
+
+  public static resetInstance(): void {
+    HackMDClient.accessToken = '';
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,7 @@ import {
   HackMDNote,
   HackMDResponse,
   HackMDUser,
+  isHackMDUser,
   NoteOptions,
 } from './types';
 
@@ -128,20 +129,10 @@ export class HackMDClient {
     }
   }
 
-  private isHackMDUser(data: unknown): data is HackMDUser {
-    return (
-      typeof data === 'object' &&
-      data !== null &&
-      'id' in data &&
-      'name' in data &&
-      'userPath' in data
-    );
-  }
-
   // Gets the current user's information
   async getMe(): Promise<HackMDUser> {
     const response = await this.request('GET', '/me');
-    if (!response.data || !this.isHackMDUser(response.data)) {
+    if (!response.data || !isHackMDUser(response.data)) {
       throw new HackMDError(
         'Failed to get user information',
         HackMDErrorType.NOT_FOUND
@@ -198,10 +189,13 @@ export class HackMDClient {
     // Both successful deletion and "already deleted" cases return true
     return true;
   }
+}
 
-  // Extracts note ID from HackMD URL
-  public getIdFromUrl(url: string): string | null {
-    const match = url.match(/hackmd\.io\/(?:@[^/]+\/)?([a-zA-Z0-9_-]+)/);
-    return match ? match[1] : null;
-  }
+export function getIdFromUrl(url: string): string | null {
+  const match = url.match(/hackmd\.io\/(?:@[^/]+\/)?([a-zA-Z0-9_-]+)/);
+  return match ? match[1] : null;
+}
+
+export function getUrlFromId(noteId: string): string {
+  return `https://hackmd.io/${noteId}`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,12 +25,10 @@ import {
 
 export default class HackMDPlugin extends Plugin {
   settings: HackMDPluginSettings;
-  private client!: HackMDClient;
   private readonly SYNC_TIME_MARGIN = 4000;
 
   async onload() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-    this.resetClient();
     this.registerEditorCommands();
     this.registerStandaloneCommands();
     this.addSettingTab(new HackMDSettingTab(this.app, this));
@@ -116,24 +114,8 @@ export default class HackMDPlugin extends Plugin {
     };
   }
 
-  public async resetClient(): Promise<void> {
-    try {
-      if (!this.settings.accessToken) throw new Error();
-      this.client = new HackMDClient(this.settings.accessToken);
-      await this.client.getMe();
-    } catch (error) {
-      throw new HackMDError(
-        'Failed to initialize HackMD client. Check your access token.',
-        HackMDErrorType.AUTH_FAILED
-      );
-    }
-  }
-
-  public async getClient(): Promise<HackMDClient> {
-    if (!this.client) {
-      await this.resetClient();
-    }
-    return this.client;
+  private async getClient(): Promise<HackMDClient> {
+    return HackMDClient.getInstance(this.settings.accessToken);
   }
 
   private async pushToHackMD(

--- a/src/main.ts
+++ b/src/main.ts
@@ -276,7 +276,7 @@ export default class HackMDPlugin extends Plugin {
       `This note already exists at "${existingNote.path}". Open it and use the "Pull" command to update its content.`
     );
     // Optionally open the existing note
-    this.app.workspace.getLeaf().openFile(existingNote);
+    this.app.workspace.getLeaf(true).openFile(existingNote);
   }
 
   /**
@@ -339,7 +339,9 @@ export default class HackMDPlugin extends Plugin {
 
       // Create note with unique filename
       const fileName = this.generateUniqueFileName(noteTitle);
-      await this.app.vault.create(fileName, finalContent);
+      const newFile = await this.app.vault.create(fileName, finalContent);
+
+      this.app.workspace.getLeaf(true).openFile(newFile);
 
       // Notify user
       this.notifyNoteCreation(fileName);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import {
   CommentPermissionType,
 } from '@hackmd/api/dist/type';
 import type HackMDPlugin from './main';
+import { HackMDClient } from './client';
 
 // Plugin settings configuration
 export interface HackMDPluginSettings {
@@ -49,7 +50,7 @@ export class HackMDSettingTab extends PluginSettingTab {
           .onChange(async value => {
             this.plugin.settings.accessToken = value;
             await this.plugin.saveData(this.plugin.settings);
-            this.plugin.resetClient();
+            HackMDClient.resetInstance();
           })
       );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian';
+import { Editor } from 'obsidian';
 import {
   NotePermissionRole,
   CommentPermissionType,
@@ -13,8 +13,20 @@ export interface HackMDMetadata {
 }
 
 // Note frontmatter structure
-export interface NoteFrontmatter {
+export interface NoteFrontmatter extends Partial<HackMDMetadata> {
   [key: string]: any;
+}
+
+export interface SyncPrepareResult {
+  content: string;
+  frontmatter: NoteFrontmatter | null;
+  noteId: string | null;
+}
+
+export interface UpdateLocalNoteParams {
+  editor: Editor;
+  content?: string;
+  metadata: Partial<HackMDMetadata>;
 }
 
 // Response types for HackMD API - simplified to what we use
@@ -66,14 +78,14 @@ export interface ModalConfig {
 }
 
 // Type guards
-export function isHackMDMetadata(value: any): value is HackMDMetadata {
-  return (
-    value &&
-    typeof value === 'object' &&
-    'url' in value &&
-    'title' in value &&
-    'lastSync' in value
-  );
+export function isHackMDMetadata(
+  value: NoteFrontmatter
+): value is HackMDMetadata {
+  return 'url' in value && 'title' in value && 'lastSync' in value;
+}
+
+export function isHackMDUser(data: object): data is HackMDUser {
+  return data !== null && 'id' in data && 'name' in data && 'userPath' in data;
 }
 
 export function hasFrontmatter(content: string): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,18 +14,32 @@ export interface HackMDMetadata {
 
 // Note frontmatter structure
 export interface NoteFrontmatter {
-  hackmd?: HackMDMetadata;
   [key: string]: any;
 }
 
-// HackMD API response
-export interface HackMDResponse {
-  status: number;
-  data: any;
-  ok: boolean;
+// Response types for HackMD API - simplified to what we use
+export interface HackMDNote {
+  id: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  lastChangedAt?: string;
+  teamPath?: string;
 }
 
-// Note creation/update options
+export interface HackMDUser {
+  id: string;
+  name: string;
+  userPath: string;
+}
+
+export interface HackMDResponse {
+  status: number;
+  ok: boolean;
+  data: HackMDNote | HackMDUser | null;
+}
+
+// Only the options we actually send to the API
 export interface NoteOptions {
   title?: string;
   content?: string;
@@ -40,18 +54,6 @@ export interface HackMDPluginSettings {
   defaultReadPermission: NotePermissionRole;
   defaultWritePermission: NotePermissionRole;
   defaultCommentPermission: CommentPermissionType;
-  noteIdMap: Record<string, string>;
-  lastSyncTimestamps: Record<string, number>;
-}
-
-// Sync state between local and remote notes
-export interface SyncState {
-  file: TFile;
-  localModTime: number;
-  remoteModTime: number;
-  lastSyncTime: number;
-  contentChanged: boolean;
-  metadataChanged: boolean;
 }
 
 // Modal configuration
@@ -139,13 +141,6 @@ export const CONSTANTS = {
   DEFAULT_TIMEOUT: 10000,
   MAX_RETRIES: 3,
 } as const;
-
-// Utility types
-export type AsyncResult<T> = Promise<{
-  success: boolean;
-  data?: T;
-  error?: HackMDError;
-}>;
 
 export type SyncDirection = 'push' | 'pull';
 export type SyncMode = 'normal' | 'force';


### PR DESCRIPTION
This PR adds a new command that allows users to create Obsidian notes directly from any HackMD URL, making it easier to import external HackMD content into Obsidian.

**Note:** This PR is stacked on top of the "fix-5-6" [PR#7](https://github.com/thor314/hackmd-obsidian/pull/7#issue-2878644444) and requires that PR to be merged first.

## What's new

- Added a new command palette entry: "Create Note from HackMD URL"
- Implemented URL prompt modal with validation
- Notes created from HackMD URLs open in their own tab without affecting the active editor
- Improved error handling with user-friendly notifications
- Prevents duplicate notes by detecting if a note with the same HackMD ID already exists in the vault
- Manages filename collisions by automatically numbering new notes when needed

## Technical improvements

To support this feature reliably, I've made several architectural improvements:

- Implemented singleton pattern for HackMD client
- Standardized URL handling across the codebase
- Enhanced type safety with interfaces and type guards
- Improved error handling throughout the client class
- Simplified types by moving API interfaces to a dedicated file
- Fixed UI issues when creating notes from HackMD URLs

## Testing

1. Open command palette
2. Select "Create Note from HackMD URL"
3. Enter a valid HackMD URL
4. Verify the note is created and opened in a new tab
5. Test duplicate detection by trying to create a note from a HackMD URL that's already in your vault
6. Test filename collision handling by creating notes with potentially conflicting names

The implementation preserves existing frontmatter while generating fresh synchronization metadata, and prevents duplicate notes with the same HackMD ID.

I've tried to keep the changes well-organized through focused commits, though the refactoring is substantial. Happy to discuss any aspect of the implementation in more detail.